### PR TITLE
Create private gists instead of public ones

### DIFF
--- a/src/GithubConnector.js
+++ b/src/GithubConnector.js
@@ -246,7 +246,7 @@ export default class GithubConnector {
             cache: "no-store",
             body: JSON.stringify({
                 "description": name,
-                "public": true,
+                "public": false,
                 "files": this.getDefaultFiles(name)
             })
         };


### PR DESCRIPTION
A public gist cannot be made private, a private gist however can be made public later on.
This lets the user choose and prevents accidental leaks of any kind of information

Private gists have been tested and are working normally with the IDE